### PR TITLE
Fixes ID's and switches class names to match tree node types

### DIFF
--- a/client/railroadDiagrams/railroad-diagrams.js
+++ b/client/railroadDiagrams/railroad-diagrams.js
@@ -226,9 +226,9 @@ var options = {
     return this.$super.toString.call(this);
   }
 
-  function Sequence(id, items) {
-    if(!(this instanceof Sequence)) return new Sequence(id, [].slice.call(arguments, 1));
-    FakeSVG.call(this, 'g', {class: 'sequence', id: id});
+  function Sequence(id, className, items) {
+    if(!(this instanceof Sequence)) return new Sequence(id, className, [].slice.call(arguments, 2));
+    FakeSVG.call(this, 'g', {class: className, id: id});
     this.items = items.map(wrapString);
     this.width = this.items.reduce(function(sofar, el) { return sofar + el.width + (el.needsSpace?20:0)}, 0);
     this.up = this.items.reduce(function(sofar,el) { return Math.max(sofar, el.up)}, 0);
@@ -258,9 +258,9 @@ var options = {
     return this;
   }
 
-  function Choice(normal, id, items) {
-    if(!(this instanceof Choice)) return new Choice(normal, id, [].slice.call(arguments,2));
-    FakeSVG.call(this, 'g', {class: 'choice', id: id});
+  function Choice(normal, id, className, items) {
+    if(!(this instanceof Choice)) return new Choice(normal, id, className, [].slice.call(arguments,3));
+    FakeSVG.call(this, 'g', {class: className, id: id});
     if( typeof normal !== "number" || normal !== Math.floor(normal) ) {
       throw new TypeError("The first argument of Choice() must be an integer.");
     } else if(normal < 0 || normal >= items.length) {
@@ -321,18 +321,18 @@ var options = {
     return this;
   }
 
-  function Optional(item, id, skip) {
+  function Optional(item, id, className, skip) {
     if( skip === undefined )
-      return Choice(1, id, Skip(), item);
+      return Choice(1, id, className, Skip(), item);
     else if ( skip === "skip" )
-      return Choice(0, id, Skip(), item);
+      return Choice(0, id, className, Skip(), item);
     else
       throw "Unknown value for Optional()'s 'skip' argument.";
   }
 
-  function Group(item, id, caption) {
-    if(!(this instanceof Group)) return new Group(item, id, caption);
-    FakeSVG.call(this, 'g', {class: 'group', id: id});
+  function Group(item, id, className, caption) {
+    if(!(this instanceof Group)) return new Group(item, id, className, caption);
+    FakeSVG.call(this, 'g', {class: className, id: id});
     caption = caption || (new Skip);
     this.item = wrapString(item);
     this.caption = caption;
@@ -371,9 +371,9 @@ var options = {
     return this;
   }
 
-  function OneOrMore(item, id, rep) {
-    if(!(this instanceof OneOrMore)) return new OneOrMore(item, id, rep);
-    FakeSVG.call(this, 'g', {class: 'oneormore', id: id});
+  function OneOrMore(item, id, className, rep) {
+    if(!(this instanceof OneOrMore)) return new OneOrMore(item, id, className, rep);
+    FakeSVG.call(this, 'g', {class: className, id: id});
     rep = rep || (new Skip);
     this.item = wrapString(item);
     this.rep = wrapString(rep);
@@ -404,9 +404,9 @@ var options = {
     return this;
   }
 
-  //DO WE NEED THE ID ON THE ONEORMORE, OR THE OPTIONAL
-  function ZeroOrMore(item, id, rep, skip) {
-    return Optional(OneOrMore(item, id, rep), null, skip);
+  //DO WE NEED THE ID/CLASS ON THE ONEORMORE, OR THE OPTIONAL, OR BOTH
+  function ZeroOrMore(item, id, className, rep, skip) {
+    return Optional(OneOrMore(item, id, className, rep), id, className, skip);
   }
 
   function Start() {
@@ -435,9 +435,9 @@ var options = {
     return this;
   }
 
-  function Terminal(text, id) {
-    if(!(this instanceof Terminal)) return new Terminal(text, id);
-    FakeSVG.call(this, 'g', {class: 'terminal', id: id});
+  function Terminal(text, id, className) {
+    if(!(this instanceof Terminal)) return new Terminal(text, id, className);
+    FakeSVG.call(this, 'g', {class: className, id: id});
     this.text = text;
     this.width = text.length * 8 + 20; /* Assume that each char is .5em, and that the em is 16px */
     this.up = 11;
@@ -457,9 +457,9 @@ var options = {
     return this;
   }
 
-  function NonTerminal(text, id) {
-    if(!(this instanceof NonTerminal)) return new NonTerminal(text, id);
-    FakeSVG.call(this, 'g', {class: 'non-terminal', id: id});
+  function NonTerminal(text, id, className) {
+    if(!(this instanceof NonTerminal)) return new NonTerminal(text, id, className);
+    FakeSVG.call(this, 'g', {class: className, id: id});
     this.text = text;
     this.width = text.length * 8 + 20;
     this.up = 11;


### PR DESCRIPTION
Fixed the ID's. The dom tree should match the regex tree now. The only weird part is text where the regex tree will have a separate node for each letter, but the dom tree combines all letters next to each other into one node. I made it so that every text node in the regex tree that is tied to the same direct parent will have the same ID. That might need to be changed later. 

Also switched the class names to match the regex tree instead of the railroad components (instead of sequence, it might be match, etc.)
