### PR TITLE
Revert changes to alternates

### DIFF
--- a/client/components/workspace/workspace.factory.js
+++ b/client/components/workspace/workspace.factory.js
@@ -29,7 +29,7 @@
         'text': text,
         // 'testText': testText,
         'capture-group': '{"type": "capture-group", "body":' + text + '}',
-        'alternate': '{"type": "alternate", "left":' + text + ', "right":' + text + '}',
+        'alternate': '{"type": "capture-group", "body": {"type": "alternate", "left":' + text + ', "right":' + text + '}}',
         'optional': '{"type": "quantified", "body": {"type": "capture-group", "body":' + text + '}, "quantifier": {"min": 0, "max": 1}}',
         'repeating': '{"type": "quantified", "body": {"type": "capture-group", "body":' + text + '}, "quantifier": {"min": 1, "max": null}}'
       };

--- a/client/components/workspace/workspace.specs.js
+++ b/client/components/workspace/workspace.specs.js
@@ -72,7 +72,7 @@ describe('Workspace', function() {
     describe('handles choice blocks\n', function(){
       it('should support alternate objects', function(){
         var alternate = workspace.getComponentNode('alternate');
-        expect(JSON.stringify(alternate)).toEqual('{"type":"alternate","left":' + JSON.stringify(text) + ',"right":' + JSON.stringify(text) + '}');
+        expect(JSON.stringify(alternate)).toEqual('{"type":"capture-group","body":{"type":"alternate","left":' + JSON.stringify(text) + ',"right":' + JSON.stringify(text) + '}}');
       });
 
       it('should support optional blocks', function(){


### PR DESCRIPTION
Turns out they need to be capture groups, it "contains" the alternates, otherwise they can get combined in with other nodes.